### PR TITLE
Sets up the core to use the prod binary, rather than debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@
 - @potocpav for the json-rpc client I stole from [xi_glium](https://github.com/potocpav/xi_glium).
 - @ticki for [termion](https://github.com/ticki/termion), on which this project is based.
 
+## Running the Core
+
+The frontend assumes that you have installed the [core editor](https://github.com/google/xi-editor)
+and is available in your PATH. The following should suffice:
+
+```bash
+git clone https://github.com/google/xi-editor
+cd xi-editor/rust
+cargo install
+# You now need to add ~/.cargo/bin to your PATH (this is where `cargo install`
+# places binaries). In your .bashrc (or equivalent), add `export PATH=$PATH:~/.cargo/bin`
+```
+
 ## Caveats
 
 ### Tabs

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ impl Default for Input {
 
 fn main() {
     log4rs::init_file("log_config.yaml", Default::default()).unwrap();
-    let mut core = Core::new("../xi-editor/rust/target/debug/xi-core");
+    let mut core = Core::new("xi-core");
     let mut screen = Screen::new();
     let mut input = Input::new();
     input.run();


### PR DESCRIPTION
Also updates the README to reflect this change.
Adds instructions for how to install the prod version of the core, and get it in your path