### PR TITLE
Uses Makefile for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rust:
 cache: cargo
 before_script: (cargo install rustfmt || true)
 script:
-  - cargo fmt
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]] ; then cargo build --features clippy ; else cargo build ; fi'
+  - make build
+  - make test
+  - make fmt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: all build test fmt clean
+
+FEATURES =
+TRAVIS_RUST_VERSION ?= stable
+ifeq (nightly, $(TRAVIS_RUST_VERSION))
+	FEATURES=clippy
+endif
+
+all: build
+
+build: src
+	cargo build --features "$(FEATURES)"
+
+test:
+	cargo test --features "$(FEATURES)"
+
+fmt:
+	cargo fmt
+
+clean:
+	rm -rf target


### PR DESCRIPTION
Using the bash -c conditional in .travis.yml works fine, but it doesn't
provide great log output in builds as to what was actually run in
travis. Make is a good solution to this.