### PR TITLE
refactor rendering & handle cursor properly

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -122,7 +122,7 @@ impl Core {
             view.update_cursor(cursor);
             Ok(())
         } else {
-            error!("View {} not found", &self.current_view);
+            error!("View {} not found", self.current_view.as_str());
             bail!(ErrorKind::UpdateError);
         }
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -11,6 +11,7 @@ use std::thread;
 use serde_json;
 use serde_json::Value;
 
+use cursor::Cursor;
 use update::Update;
 use view::View;
 use errors::*;
@@ -107,7 +108,19 @@ impl Core {
         info!("Updating current view");
 
         if let Some(view) = self.views.get_mut(&self.current_view) {
-            view.update(update)
+            view.update_lines(update)
+        } else {
+            error!("View {} not found", &self.current_view);
+            bail!(ErrorKind::UpdateError);
+        }
+    }
+
+    pub fn scroll_to(&mut self, cursor: &Cursor) -> Result<()> {
+        info!("Updating cursor position");
+
+        if let Some(view) = self.views.get_mut(&self.current_view) {
+            view.update_cursor(cursor);
+            Ok(())
         } else {
             error!("View {} not found", &self.current_view);
             bail!(ErrorKind::UpdateError);
@@ -116,6 +129,10 @@ impl Core {
 
     pub fn get_view(&self) -> Option<&View> {
         self.views.get(&self.current_view)
+    }
+
+    pub fn get_view_mut(&mut self) -> Option<&mut View> {
+        self.views.get_mut(&self.current_view)
     }
 
     /// Build and send a JSON RPC request, returning the associated request ID to pair it with
@@ -167,7 +184,7 @@ impl Core {
         assert_eq!(i, id);
         // TODO: in the future, the caller should handle the error. For now we just log it and move
         // on, returning a generic RpcError.
-        result.or_else(|err| {
+        result.or_else(|_| {
             error!("synchronous call returned with an error");
             Err(ErrorKind::RpcError.into())
         })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -5,10 +5,10 @@ pub struct Cursor {
 }
 
 impl From<(u64, u64)> for Cursor {
-    fn from(coord: (u64, u64)) -> Self {
+    fn from(pair: (u64, u64)) -> Self {
         Cursor {
-            line: (coord.0 & u16::max_value() as u64) as u16,
-            column: (coord.1 & u16::max_value() as u64) as u16,
+            line: (pair.0 & u16::max_value() as u64) as u16,
+            column: (pair.1 & u16::max_value() as u64) as u16,
         }
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,15 @@
+#[derive(Clone, Debug)]
+pub struct Cursor {
+    pub line: u16,
+    pub column: u16,
+}
+
+impl From<(u64, u64)> for Cursor {
+    fn from(coord: (u64, u64)) -> Self {
+        Cursor {
+            line: (coord.0 & u16::max_value() as u64) as u16,
+            column: (coord.1 & u16::max_value() as u64) as u16,
+        }
+    }
+}
+

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,7 +1,9 @@
 use std::io::Write;
 use std::default::Default;
 
-use termion::{clear, style, cursor};
+use termion::clear;
+use termion::cursor;
+use termion::style;
 
 use cursor::Cursor;
 use errors::*;
@@ -14,7 +16,7 @@ fn _return_true() -> bool {
 pub struct Line {
     pub text: Option<String>,
     #[serde(rename="cursor")]
-    pub cursors: Option<Vec<u16>>,
+    pub cursors: Option<Vec<u64>>,
     pub styles: Option<Vec<i64>>,
     #[serde(default="_return_true")]
     #[serde(skip_deserializing)]
@@ -52,7 +54,7 @@ impl Line {
                 // If this cursor is the real cursor we don't want to draw it.
                 // We skip it, and the cursor will be set here later.
                 if let Some(real_cursor) = cursor {
-                    if real_cursor.column == *idx {
+                    if real_cursor.column as u64 == *idx {
                         continue;
                     }
                 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,7 +1,9 @@
+use std::io::Write;
 use std::default::Default;
 
-use termion::style;
+use termion::{clear, style, cursor};
 
+use cursor::Cursor;
 use errors::*;
 
 fn _return_true() -> bool {
@@ -11,7 +13,8 @@ fn _return_true() -> bool {
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct Line {
     pub text: Option<String>,
-    pub cursor: Option<Vec<u64>>,
+    #[serde(rename="cursor")]
+    pub cursors: Option<Vec<u16>>,
     pub styles: Option<Vec<i64>>,
     #[serde(default="_return_true")]
     #[serde(skip_deserializing)]
@@ -22,7 +25,7 @@ impl Default for Line {
     fn default() -> Line {
         Line {
             text: None,
-            cursor: None,
+            cursors: None,
             styles: None,
             is_valid: true,
         }
@@ -30,34 +33,54 @@ impl Default for Line {
 }
 
 impl Line {
-    pub fn invalid() -> Line {
-        Line {
-            is_valid: false,
-            ..Default::default()
-        }
-    }
-
     /// Insert the cursors and handle styles (not implemented yet)
-    pub fn render(&self) -> Result<String> {
+    pub fn render<W: Write>(&self, w: &mut W, lineno: u16, cursor: Option<&Cursor>) -> Result<()> {
         let mut line = self.text
                            .as_ref()
                            .map(|s| s.clone())
                            .unwrap_or(String::new());
-        self.pad(&mut line);
-        if let Some(cursors) = self.cursor.as_ref() {
+
+        // Draw "fake" cursors. we have only one "real" cursor in a terminal so we render the
+        // others manually by inserting escape sequences in the string.
+        if let Some(ref cursors) = self.cursors {
+            // We need to keep track of the escape sequences we add, since they count as 1
+            // character and change the indices. One solution to avoid that would be to insert them
+            // right to left.
             let mut offset: usize = 0;
+
             for idx in cursors {
+                // If this cursor is the real cursor we don't want to draw it.
+                // We skip it, and the cursor will be set here later.
+                if let Some(real_cursor) = cursor {
+                    if real_cursor.column == *idx {
+                        continue;
+                    }
+                }
+
+                // Make sure the cursor is within the bounds of the string. It *should* be the case
+                // after padding, assuming the core sends correct updates, but better be safe than
+                // sorry. Note that padding is necessary for cases where the cursor is at the end
+                // of the line.
+                self.pad(&mut line);
                 let idx = offset + *idx as usize;
                 if idx + 1 > line.len() {
-                    error!("Cannot set cursor: cursor index {} is bigger than line length ({})", idx, line.len());
+                    error!(
+                        "Cannot set cursor: cursor index {} is bigger than line length ({})",
+                        idx,
+                        line.len());
                     bail!(ErrorKind::DisplayError);
                 }
+
+                // Insert the "cursor".
                 line.insert_str(idx + 1, &format!("{}", style::Reset));
                 line.insert_str(idx, &format!("{}", style::Invert));
                 offset += 2;
             }
         }
-        Ok(line)
+        write!(w, "{}{}{}", cursor::Goto(1, lineno), line, clear::AfterCursor)
+            .chain_err(|| ErrorKind::DisplayError)?;
+        w.flush().chain_err(|| ErrorKind::DisplayError)?;
+        Ok(())
     }
 
     fn pad(&self, text: &mut String) {

--- a/src/line.rs
+++ b/src/line.rs
@@ -77,7 +77,7 @@ impl Line {
                 offset += 2;
             }
         }
-        write!(w, "{}{}{}", cursor::Goto(1, lineno), line, clear::AfterCursor)
+        write!(w, "{}{}{}", cursor::Goto(1, lineno), clear::CurrentLine, line)
             .chain_err(|| ErrorKind::DisplayError)?;
         w.flush().chain_err(|| ErrorKind::DisplayError)?;
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ fn run() -> Result<()> {
     let mut screen = Screen::new()?;
     let mut input = Input::new();
     input.run();
+    screen.init()?;
     core.open(file)?;
     core.scroll(0, screen.size.1 as u64)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ extern crate serde_json;
 extern crate termion;
 
 mod core;
+mod cursor;
 mod errors;
 mod input;
 mod line;
@@ -69,9 +70,8 @@ fn run() -> Result<()> {
     let mut screen = Screen::new()?;
     let mut input = Input::new();
     input.run();
-    screen.init()?;
     core.open(file)?;
-    core.scroll(0, screen.size.1 as u64 - 2)?;
+    core.scroll(0, screen.size.1 as u64)?;
 
     loop {
         if let Ok(event) = input.try_recv() {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -73,7 +73,7 @@ impl Operation {
                 let lines = self.lines.clone().unwrap();
                 for i in old_ix..new_ix {
                     let mut line = old_lines[i as usize].clone();
-                    line.cursor = lines[i as usize].cursor.clone();
+                    line.cursors = lines[i as usize].cursors.clone();
                     line.styles = lines[i as usize].styles.clone();
                     new_lines.push(line);
                 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,16 +1,16 @@
-use std::{self, cmp, thread, time};
-use std::io::{stdout, Write};
+use std::{self, thread, time};
+use std::io::stdout;
 
 use serde_json;
 
-use termion::{self, clear, cursor, style};
+use termion;
 use termion::input::MouseTerminal;
 use termion::raw::{IntoRawMode, RawTerminal};
 use termion::screen::AlternateScreen;
 
 use core::Core;
+use cursor::Cursor;
 use errors::*;
-use view::View;
 
 pub struct Screen {
     pub stdout: MouseTerminal<AlternateScreen<RawTerminal<std::io::Stdout>>>,
@@ -26,46 +26,6 @@ impl Screen {
            })
     }
 
-    pub fn draw(&mut self, view: &View) -> Result<()> {
-        write!(self.stdout, "{}{}", clear::All, cursor::Up(self.size.1))
-            .chain_err(|| ErrorKind::DisplayError)?;
-
-        let mut invalid_lines: usize = 0;
-        for (lineno, line) in view.lines.iter().enumerate() {
-            if line.is_valid {
-                let text = line.render()?;
-                write!(self.stdout, "{}{}{}", cursor::Goto(1, 1 + (lineno - invalid_lines) as u16), text, cursor::Hide)
-                    .chain_err(|| ErrorKind::DisplayError)?;
-            } else {
-                invalid_lines += 1;
-            }
-            if lineno > invalid_lines && (lineno - invalid_lines) == self.size.1 as usize {
-                break;
-            }
-        }
-        self.stdout
-            .flush()
-            .chain_err(|| ErrorKind::DisplayError)?;
-        Ok(())
-    }
-
-    pub fn scroll_to(&mut self, _col: u64, _line: u64) {
-        // We draw "fake" cursor(s) while rendering the lines. so there's nothing to do here.
-        // However, on the long term, we do want to set the cursor correctly, so that it can blink.
-        // One problem is that xi-core returns gives the position of the cursor as a string index.
-        // But we have some characters that are more or less large: a tab can be multiple spaces
-        // for example. So we need some logic to know exactly where the cursor should be set.
-    }
-
-    pub fn init(&mut self) -> Result<()> {
-        write!(self.stdout, "{}{}", clear::All, cursor::Up(self.size.1))
-            .chain_err(|| ErrorKind::DisplayError)?;
-        self.stdout
-            .flush()
-            .chain_err(|| ErrorKind::DisplayError)?;
-        Ok(())
-    }
-
     pub fn update(&mut self, core: &mut Core) -> Result<()> {
         // TODO(#27): check if terminal size changed. If so, send a `render_line` command to the
         // backend, and a `scroll` command for future updates.
@@ -77,13 +37,24 @@ impl Screen {
                 "update" => {
                     let update = serde_json::from_value(params.get("update").unwrap().clone())?;
                     core.update(&update)?;
-                    let view = core.get_view().ok_or(ErrorKind::DisplayError)?;
-                    self.draw(view)?;
+                    core.get_view_mut()
+                        .ok_or_else(|| {
+                            error!("No view found");
+                            ErrorKind::DisplayError
+                        })?
+                        .render(&mut self.stdout, self.size.1)?
                 }
                 "scroll_to" => {
-                    let (col, line) = (params.get("col").unwrap().as_u64().unwrap(),
-                                       params.get("line").unwrap().as_u64().unwrap());
-                    self.scroll_to(col, line);
+                    // Deserialize the cursor position, and let the core update the view.
+                    let coord = (params.get("line").unwrap().as_u64().unwrap(),
+                                 params.get("col").unwrap().as_u64().unwrap());
+                    core.scroll_to(&Cursor::from(coord))?;
+                    core.get_view_mut()
+                        .ok_or_else(|| {
+                            error!("No view found");
+                            ErrorKind::DisplayError
+                        })?
+                        .render(&mut self.stdout, self.size.1)?
                 }
                 "set_style" => {
                     // TODO:(#26): ???

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,9 +1,14 @@
-use std::{self, thread, time};
+use std;
 use std::io::stdout;
+use std::io::Write;
+use std::thread;
+use std::time;
 
 use serde_json;
 
 use termion;
+use termion::clear;
+use termion::cursor;
 use termion::input::MouseTerminal;
 use termion::raw::{IntoRawMode, RawTerminal};
 use termion::screen::AlternateScreen;
@@ -24,6 +29,15 @@ impl Screen {
                size: termion::terminal_size()?,
                stdout: stdout,
            })
+    }
+
+    pub fn init(&mut self) -> Result<()> {
+        write!(self.stdout, "{}{}", clear::All, cursor::Up(self.size.1))
+            .chain_err(|| ErrorKind::DisplayError)?;
+        self.stdout
+            .flush()
+            .chain_err(|| ErrorKind::DisplayError)?;
+        Ok(())
     }
 
     pub fn update(&mut self, core: &mut Core) -> Result<()> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
-use termion::{clear, cursor};
+use termion::clear;
+use termion::cursor;
 
 use cursor::Cursor;
 use errors::*;
@@ -162,14 +163,9 @@ impl View {
                     .unwrap_or("")
                     .chars()
                     .take(cursor.column as usize)
-                    .fold(0, |acc, c| {
-                        if c == '\t' {
-                            acc + TAB_LENGTH - (acc % TAB_LENGTH)
-                        } else {
-                            acc + 1
-                        }
-                    });
-                let cursor_pos = cursor::Goto(column as u16 + 1, cursor.line + 1);
+                    .fold(0 as u16, add_char_width);
+
+                let cursor_pos = cursor::Goto(column + 1, cursor.line + 1);
                 write!(w, "{}", cursor_pos)
                     .chain_err(|| ErrorKind::DisplayError)?;
                 w.flush().chain_err(|| ErrorKind::DisplayError)?;
@@ -182,5 +178,13 @@ impl View {
             warn!("No cursor to render");
         }
         Ok(())
+    }
+}
+
+fn add_char_width(acc: u16, c: char) -> u16 {
+    if c == '\t' {
+        acc + TAB_LENGTH - (acc % TAB_LENGTH)
+    } else {
+        acc + 1
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,12 +1,33 @@
+use std::io::Write;
+
+use termion::{clear, cursor};
+
+use cursor::Cursor;
 use errors::*;
 use line::Line;
 use update::Update;
 
+const TAB_LENGTH: u16 = 4;
+
 #[derive(Clone)]
 pub struct View {
     last_rev: u64,
+    state: State,
     pub filepath: String,
     pub lines: Vec<Line>,
+    pub cursor: Option<Cursor>,
+}
+
+#[derive(Clone)]
+enum State {
+    /// The view did not change since last time it was rendered
+    Clean,
+    /// The lines changes since last time the view was rendered
+    Lines,
+    /// The cursor changed since last time the view was rendered
+    Cursor,
+    /// Both the lines and the cursor changed since last time the view was rendered
+    All,
 }
 
 impl View {
@@ -15,14 +36,12 @@ impl View {
             last_rev: 0,
             filepath: filepath.to_owned(),
             lines: vec![],
+            cursor: None,
+            state: State::Clean,
         }
     }
 
-    pub fn update(&mut self, update: &Update) -> Result<()> {
-        // if self.last_rev > update.rev {
-        //     return;
-        // }
-
+    pub fn update_lines(&mut self, update: &Update) -> Result<()> {
         let mut lines = vec![];
         let mut index = 0;
 
@@ -30,8 +49,138 @@ impl View {
             index = operation.apply(&self.lines, index, &mut lines)?;
         }
 
-        // self.last_rev = update.rev;
         self.lines = lines;
+        self.set_dirty_lines();
+        Ok(())
+    }
+
+    pub fn update_cursor(&mut self, cursor: &Cursor) {
+        self.cursor = Some(cursor.clone());
+        self.set_dirty_cursor();
+    }
+
+    /// Return true if the lines were updated since last time the view was rendered.
+    fn dirty_lines(&self) -> bool {
+        match self.state {
+            State::All | State::Lines => true,
+            _ => false,
+        }
+    }
+
+    fn dirty_cursor(&self) -> bool {
+        match self.state {
+            State::All | State::Cursor => true,
+            _ => false,
+        }
+    }
+
+    fn set_dirty_lines(&mut self) {
+        match self.state {
+            State::Clean => self.state = State::Lines,
+            State::Cursor => self.state = State::All,
+            _ => {}
+        }
+    }
+
+    fn set_dirty_cursor(&mut self) {
+        match self.state {
+            State::Clean => self.state = State::Cursor,
+            State::Lines => self.state = State::All,
+            _ => {}
+        }
+    }
+
+    fn set_clean_lines(&mut self) {
+        match self.state {
+            State::All => self.state = State::Cursor,
+            State::Lines => self.state = State::Clean,
+            _ => {}
+        }
+    }
+
+    fn set_clean_cursor(&mut self) {
+        match self.state {
+            State::All => self.state = State::Lines,
+            State::Cursor => self.state = State::Clean,
+            _ => {}
+        }
+    }
+
+    pub fn render<W: Write>(&mut self, w: &mut W, height: u16) -> Result<()> {
+        if self.dirty_lines() {
+            write!(w, "{}{}", cursor::Goto(1, 1), clear::All)
+                .chain_err(|| ErrorKind::DisplayError)?;
+
+            self.render_lines(w, height)?;
+            self.set_clean_lines();
+        }
+
+        if self.dirty_cursor() {
+            self.render_cursor(w)?;
+            self.set_clean_cursor();
+        }
+        Ok(())
+    }
+
+    fn render_lines<W: Write>(&self, w: &mut W, height: u16) -> Result<()> {
+        let mut invalid_lines: usize = 0;
+        for (lineno, line) in self.lines.iter().enumerate() {
+            if line.is_valid {
+                // Lines are drawn with fake cursors.
+                // We set the actual cursor later, redrawing the line in the process.
+                line.render(w, (lineno - invalid_lines) as u16 + 1, None)?;
+            } else {
+                invalid_lines += 1;
+            }
+            if lineno > invalid_lines && (lineno - invalid_lines) == height as usize {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn render_cursor<W: Write>(&self, w: &mut W) -> Result<()> {
+        if let Some(cursor) = self.cursor.as_ref() {
+            if cursor.line as usize <= self.lines.len() {
+                // Redraw the line without the fake cursor
+                let line = self.lines
+                    .get(cursor.line as usize)
+                    .and_then(|line| if line.is_valid { Some(line) } else { None })
+                    .ok_or_else(|| {
+                        error!("No valid line at cursor index {}", cursor.line);
+                        ErrorKind::DisplayError
+                    })?;
+                line.render(w, cursor.line + 1, Some(cursor))?;
+
+                // Draw the cursor. The trick is that some characters are larger than others.
+                //
+                // For the moment, we only handle tabs, and we assume the terminal has tabstops of
+                // TAB_LENGTH.
+                let column = line.text
+                    .as_ref()
+                    .map(|s| &**s)
+                    .unwrap_or("")
+                    .chars()
+                    .take(cursor.column as usize)
+                    .fold(0, |acc, c| {
+                        if c == '\t' {
+                            acc + TAB_LENGTH - (acc % TAB_LENGTH)
+                        } else {
+                            acc + 1
+                        }
+                    });
+                let cursor_pos = cursor::Goto(column as u16 + 1, cursor.line + 1);
+                write!(w, "{}", cursor_pos)
+                    .chain_err(|| ErrorKind::DisplayError)?;
+                w.flush().chain_err(|| ErrorKind::DisplayError)?;
+            } else {
+                error!("Cursor is on line {} but we have only {} lines",
+                       cursor.line, self.lines.len());
+                bail!(ErrorKind::DisplayError)
+            }
+        } else {
+            warn!("No cursor to render");
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
1. Introduce a "dirty" state for the view. A view is "dirty" if it has
been updated but not rendered yet. Two things can be dirty: the line
cache, and the cursor. Making this distinction allows us to avoid
re-drawing the whole screen just to update the cursor position.

2. Move the rendering from screen.rs to view.rs and line.rs. Due to the
previous change, after drawing the view, we need to mark it as "clean".
That means we need to mutate the view, which would change force us to
pass a mutable reference of the view to the screen, for just updating
the state. Instead, it seems cleaner to pass stdout from the screen to
the view, and let it render itself and update its state accordingly.

3. Handle the cursor properly for ascii characters. Before, we were
printing "fake" cursors because we were not able to find where the
cursor should be set when a line contained tabs (\t). The problem is
that tabs have inconsistent length. We now handle this correctly.
However we assume tabs are 4 spaces large. So when using xi-tui, one
must run `tab -4`.