### PR TITLE
Correct install instructions for the syntect-plugin at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install
 
 # if you want syntax highlighting, you need to install the syntect plugin:
 cd syntect-plugin
-cargo install
+make install
 
 # You need to add ~/.cargo/bin to your PATH
 # (this is where `cargo install` places binaries).


### PR DESCRIPTION
We should use make install since this plugin need to be installed inside of the ~/.config/xi/plugins directory
as well the fork https://github.com/bytebuddha/xi-tui/commit/c136ebaa3bcb4b70152253c1c1eec93197d07cb0 handle that