### PR TITLE
Client started fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xrl 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xrl 0.0.5 (git+https://github.com/xi-frontend/xrl)",
 ]
 
 [[package]]
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "xrl"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/xi-frontend/xrl#4ab88f0ca508ef655d92e8dd127b26ae606edf63"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1106,5 +1106,5 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum xrl 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d8957597cee1b07f35e62b061e3dfa9828d69c743f21c35efba9b29c09e161c1"
+"checksum xrl 0.0.5 (git+https://github.com/xi-frontend/xrl)" = "<none>"
 "checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ log4rs = "0.8.0"
 termion = "1.5.1"
 tokio-core = "0.1.12"
 xdg = "2.1.0"
-xrl = "0.0.5"
+# xrl = "0.0.5"
+xrl = { git = "https://github.com/xi-frontend/xrl" }
 
 [dependencies.clippy]
 optional = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ extern crate log4rs;
 extern crate futures;
 extern crate termion;
 extern crate tokio_core;
-extern crate xrl;
 extern crate xdg;
+extern crate xrl;
 
 mod tui;
 mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,8 @@ fn run() -> Result<()> {
 
     info!("initializing the TUI");
     let mut tui =
-        Tui::new(core.handle(), client, core_events_rx).chain_err(|| "failed initialize the TUI")?;
+        Tui::new(&mut core, client, core_events_rx).chain_err(|| "failed initialize the TUI")?;
+
     tui.open(matches.value_of("file").unwrap_or("").to_string());
     tui.set_theme("base16-eighties.dark");
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -40,8 +40,14 @@ impl Tui {
     ) -> Result<Self> {
         let mut styles = HashMap::new();
         styles.insert(0, Default::default());
-        let conf_dir = BaseDirectories::with_prefix("xi").ok().and_then(|dirs| Some(dirs.get_config_home().to_string_lossy().into_owned()));
-        core.run(client.client_started(conf_dir.as_ref().map(|dir| &**dir), None).map_err(|_|())).unwrap();
+        let conf_dir = BaseDirectories::with_prefix("xi")
+            .ok()
+            .and_then(|dirs| Some(dirs.get_config_home().to_string_lossy().into_owned()));
+        core.run(
+            client
+                .client_started(conf_dir.as_ref().map(|dir| &**dir), None)
+                .map_err(|_| ()),
+        ).unwrap();
         Ok(Tui {
             events,
             delayed_events: Vec::new(),

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use termion::event::{Event, Key, MouseButton, MouseEvent};
 use termion::clear::CurrentLine as ClearLine;
 use termion::cursor::Goto;
-use xrl::{LineCache, Line, Style, Update};
+use xrl::{Line, LineCache, Style, Update};
 
 use super::window::Window;
 use super::style::{reset_style, set_style};
@@ -45,10 +45,7 @@ impl View {
     }
 
     pub fn set_cursor(&mut self, line: u64, column: u64) {
-        self.cursor = Cursor {
-            line,
-            column,
-        };
+        self.cursor = Cursor { line, column };
         self.window.set_cursor(&self.cursor);
     }
 
@@ -72,7 +69,8 @@ impl View {
         if self.cursor.line < self.cache.before() {
             error!(
                 "cursor is on line {} but there are {} invalid lines in cache.",
-                self.cursor.line, self.cache.before()
+                self.cursor.line,
+                self.cache.before()
             );
             return;
         }


### PR DESCRIPTION
xi-term crashes with the latest version of the core because the `client_started` notification is now mandatory. See: https://github.com/google/xi-editor/issues/554