### PR TITLE
Map ctrl-H to backspace

### DIFF
--- a/src/widgets/view/view.rs
+++ b/src/widgets/view/view.rs
@@ -122,6 +122,7 @@ impl View {
                 Key::Char(c) => self.client.insert(c),
                 Key::Ctrl(c) => match c {
                     'w' => self.client.save(self.file.as_ref().unwrap()),
+                    'h' => self.client.backspace(),
                     _ => error!("un-handled input ctrl+{}", c),
                 },
                 Key::Backspace => self.client.backspace(),


### PR DESCRIPTION
Termion maps 0x7f ('^?') to Key::Backspace and the ANSI escape sequence
"^[[3~" to Key::Delete. Some terminals however, might be configured to
send 0x08 ('^H') when the backspace key is pressed ([1]).

This changeset simply allows this alternative input to perform the
backspace action, too.

[1] https://en.m.wikipedia.org/wiki/Backspace#^H