### PR TITLE
Map ctrl-H to backspace for command prompt

### DIFF
--- a/src/widgets/command_prompt.rs
+++ b/src/widgets/command_prompt.rs
@@ -23,7 +23,7 @@ impl CommandPrompt {
     pub fn handle_input(&mut self, input: &Event) -> Result<Option<Command>, ParseCommandError> {
         match input {
             Event::Key(Key::Char('\n')) => self.finalize(),
-            Event::Key(Key::Backspace) => Ok(self.back()),
+            Event::Key(Key::Backspace) | Event::Key(Key::Ctrl('h')) => Ok(self.back()),
             Event::Key(Key::Delete) => Ok(self.delete()),
             Event::Key(Key::Left) => Ok(self.left()),
             Event::Key(Key::Right) => Ok(self.right()),


### PR DESCRIPTION
This is just like 2a03218... ("Map ctrl-H to backspace") but for the
command prompt. Basically, if your terminal is configured to send ^H for
backspace, backspace won't work on the commandline. This changeset fixes
that.