### PR TITLE
Fix tabs in xi term (mostly)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "xrl"
 version = "0.0.5"
-source = "git+https://github.com/xi-frontend/xrl#3cf21cc033d7899e4420c452f425c6153a6070c5"
+source = "git+https://github.com/xi-frontend/xrl#0fc088c7705296105ddd24ef0439e15d9193f1b3"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -86,16 +86,36 @@ Future commands:
 | su | select-up | Move the cursor one line up and update the current selection accordingly |
 | sd | select-down | Move the cursor one line down and update the current selection accordingly |
 
+## Preferences
+Xi-core supports several user-configurable options through a `preferences.xiconfig` file.
+The default location for this is `$XDG_CONFIG_HOME/xi/preferences.xiconfig`, or, if
+`$XDG_CONFIG_HOME` is not set, it defaults to `$HOME/xi/preferences.xiconfig`.
+
 ## Caveats
 
 ### Tabs
 
-We assume tabs (`\t`) are 4 columns large. If that is not the case in your
-terminal, the cursor position will be inaccurate. On linux, to set the `\t`
-width to four spaces, do:
+We assume at least one of the following is true:
+
+1. the `translate_tabs_to_spaces` config option is enabled, or
+2. the `tab_size` config option matches your terminal tabstop settings.
+
+The xi-core options may be specified in your preferences.xiconfig file. For
+most filetypes, `translate_tabs_to_spaces` defaults to 'on' (although it is
+disabled for Makefiles).  The default `tab_size` is 4.
+
+Note that many terminals default to a tab size of 8. You can change your tab
+size to 4 with the command:
 
 ```
 tabs -4
+```
+
+or update your user config `tab_size` to 8:
+
+`preferences.xiconfig`:
+```
+tab_size = 8
 ```
 
 ### Colors

--- a/src/core/tui.rs
+++ b/src/core/tui.rs
@@ -152,6 +152,7 @@ pub enum CoreEvent {
     Update(Update),
     ScrollTo(ScrollTo),
     SetStyle(Style),
+    ConfigChanged(ConfigChanged)
 }
 
 impl Future for Tui {
@@ -222,8 +223,8 @@ impl Frontend for TuiService {
     fn plugin_stoped(&mut self, _plugin: PluginStoped) -> ServerResult<()> {
         Box::new(future::ok(()))
     }
-    fn config_changed(&mut self, _config: ConfigChanged) -> ServerResult<()> {
-        Box::new(future::ok(()))
+    fn config_changed(&mut self, config: ConfigChanged) -> ServerResult<()> {
+        self.send_core_event(CoreEvent::ConfigChanged(config))
     }
     fn theme_changed(&mut self, _theme: ThemeChanged) -> ServerResult<()> {
         Box::new(future::ok(()))

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -6,7 +6,7 @@ use futures::{Async, Future, Stream};
 
 use termion::event::Event;
 use tokio::run;
-use xrl::{Client, ClientResult, ScrollTo, Style, Update, ViewId};
+use xrl::{Client, ClientResult, ScrollTo, ConfigChanged, Style, Update, ViewId};
 use indexmap::IndexMap;
 use failure::Error;
 
@@ -70,6 +70,7 @@ impl Editor {
             CoreEvent::Update(update) => self.handle_update(update),
             CoreEvent::SetStyle(style) => self.handle_def_style(style),
             CoreEvent::ScrollTo(scroll_to) => self.handle_scroll_to(scroll_to),
+            CoreEvent::ConfigChanged(config) => self.handle_config_changed(config),
         }
     }
 
@@ -89,6 +90,13 @@ impl Editor {
 
     fn handle_def_style(&mut self, style: Style) {
         self.styles.insert(style.id, style);
+    }
+
+    fn handle_config_changed(&mut self, config: ConfigChanged) {
+        match self.views.get_mut(&config.view_id) {
+            Some(view) => view.config_changed(config.changes),
+            None => self.delayed_events.push(CoreEvent::ConfigChanged(config)),
+        }
     }
 }
 

--- a/src/widgets/view/client.rs
+++ b/src/widgets/view/client.rs
@@ -20,6 +20,16 @@ impl Client {
         spawn(f);
     }
 
+    pub fn insert_newline(&mut self) {
+        let f = self.inner.insert_newline(self.view_id).map_err(|_| ());
+        spawn(f);
+    }
+
+    pub fn insert_tab(&mut self) {
+        let f = self.inner.insert_tab(self.view_id).map_err(|_| ());
+        spawn(f);
+    }
+
     pub fn scroll(&mut self, start: u64, end: u64) {
         let f = self.inner.scroll(self.view_id, start, end).map_err(|_| ());
         spawn(f);

--- a/src/widgets/view/view.rs
+++ b/src/widgets/view/view.rs
@@ -68,6 +68,18 @@ impl View {
         );
     }
 
+    pub fn insert(&mut self, c: char) {
+        self.client.insert(c)
+    }
+
+    pub fn insert_newline(&mut self) {
+        self.client.insert_newline()
+    }
+
+    pub fn insert_tab(&mut self) {
+        self.client.insert_tab()
+    }
+
     pub fn save(&mut self) {
         self.client.save(self.file.as_ref().unwrap())
     }
@@ -135,7 +147,11 @@ impl View {
     pub fn handle_input(&mut self, event: Event) {
         match event {
             Event::Key(key) => match key {
-                Key::Char(c) => self.client.insert(c),
+                Key::Char(c) => match c {
+                    '\n' => self.insert_newline(),
+                    '\t' => self.insert_tab(),
+                    _ => self.insert(c),
+                }
                 Key::Ctrl(c) => match c {
                     'w' => self.save(),
                     'h' => self.back(),


### PR DESCRIPTION
Note: this PR depends on work in https://github.com/xi-frontend/xrl/pull/18

Xi-term doesn't position the cursor properly when its tab width differs from the terminal tab width (https://github.com/xi-frontend/xi-term/issues/80). We can work around this in two ways:
(1) Allow the translate_tabs_to_spaces option (when enabled) to avoid the problem entirely (translate tabs into spaces = no tabs = no problems) and
(2) Allow the user to change the tab width in their preferences.xiconfig file. This still requires a correct setting, but it at least gives the user the option to change xi-term to work with their terminal rather than the other way around.