### PR TITLE
Escape control characters and fix tab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,31 +93,6 @@ The default location for this is `$XDG_CONFIG_HOME/xi/preferences.xiconfig`, or,
 
 ## Caveats
 
-### Tabs
-
-We assume at least one of the following is true:
-
-1. the `translate_tabs_to_spaces` config option is enabled, or
-2. the `tab_size` config option matches your terminal tabstop settings.
-
-The xi-core options may be specified in your preferences.xiconfig file. For
-most filetypes, `translate_tabs_to_spaces` defaults to 'on' (although it is
-disabled for Makefiles).  The default `tab_size` is 4.
-
-Note that many terminals default to a tab size of 8. You can change your tab
-size to 4 with the command:
-
-```
-tabs -4
-```
-
-or update your user config `tab_size` to 8:
-
-`preferences.xiconfig`:
-```
-tab_size = 8
-```
-
 ### Colors
 
 If you have the `syntect` plugin installed, colors will be enabled by default, with two caveats:


### PR DESCRIPTION
I noticed that we weren't escaping control characters before writing
them out to the terminal. That's not great, since it means opening a
file that contains, say, ANSI escape sequences can change the terminal's
title, tab settings, or cause any number of other changes. We'll display
these characters using "caret notation" [1].

Consequently, we have to update our rendering code to escape these
characters and the width translation code to treat them as multi-column.

This also led to a tweak to the get_click_location() code. Before this
change, clicking on a multi-column character might position the cursor
after the character. For example, clicking the 'A' part of '^A' would
position the cursor after the '^A', rather than on the '^A'.

Finally, this changeset fixes the last of our tab problems (for now, at
least). We couldn't position our cursor properly when the terminal tab
settings and the user's preferences.xiconfig disagree on where tabstops
should be (and the user has 'translate_tabs_to_spaces' disabled), since
the terminal was rendering tabs at a different width from what we were
assuming.. We can sidestep this issue entirely by never letting the
terminal see a raw '\t'.  Instead, xi-term will translate tabs to spaces
during rendering. Since the terminal only sees spaces -- which both
xi-term and the terminal agree are one column wide -- there's no
mismatch anymore.

[1] https://en.wikipedia.org/wiki/Caret_notation

This should fully address https://github.com/xi-frontend/xi-term/issues/80.