### PR TITLE
`cargo install` fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and is available in your PATH. The following should suffice:
 ```bash
 git clone https://github.com/xi-editor/xi-editor
 cd xi-editor/rust
-cargo install
+cargo install --path .
 
 # if you want syntax highlighting, you need to install the syntect plugin:
 cd syntect-plugin


### PR DESCRIPTION
On `cargo install` step it gave me an error:
``error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead.``

So a little fix