### PR TITLE
Add move-* commands support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Currently supported commands:
 | bp | prev-buffer | Switch to the previous buffer |
 | pd | page-down | Advance the current view by one page |
 | pu | page-up | Move the current view back by one page |
+| ml | move-left | Move the cursor one position left |
+| mr | move-right | Move the cursor one position right |
+| mu | move-up | Move the cursor one line up |
+| md | move-down | Move the cursor one line down |
 | t `theme` | theme `theme-name` | Set the theme to `theme`|
 
 Future commands:
@@ -77,10 +81,6 @@ Future commands:
 | ---------- | --------- | ----------- |
 | c | close | Closes the current view |
 | ? `string` | search `string` | Search for `string` |
-| ml | move-left | Move the cursor one position left |
-| mr | move-right | Move the cursor one position right |
-| mu | move-up | Move the cursor one line up |
-| md | move-down | Move the cursor one line down |
 | sl | select-left | Move the cursor one position left and update the current selection accordingly |
 | sr | select-right | Move the cursor one position right and update the current selection accordingly |
 | su | select-up | Move the cursor one line up and update the current selection accordingly |

--- a/src/core/cmd.rs
+++ b/src/core/cmd.rs
@@ -24,6 +24,14 @@ pub enum Command {
     NextBuffer,
     /// Cycle to the previous buffer.
     PrevBuffer,
+    /// Move cursor left.
+    MoveLeft,
+    /// Move cursor right.
+    MoveRight,
+    /// Move cursor up.
+    MoveUp,
+    /// Move cursor down.
+    MoveDown,
     /// Page down
     PageDown,
     /// Page up
@@ -57,6 +65,10 @@ impl FromStr for Command {
             "bp" | "prev-buffer" =>Ok(Command::PrevBuffer),
             "pd" | "page-down" => Ok(Command::PageDown),
             "pu" | "page-up" => Ok(Command::PageUp),
+            "ml" | "move-left" => Ok(Command::MoveLeft),
+            "mr" | "move-right" => Ok(Command::MoveRight),
+            "mu" | "move-up" => Ok(Command::MoveUp),
+            "md" | "move-down" => Ok(Command::MoveDown),
             command => {
                 let mut parts: Vec<&str> = command.split(' ').collect();
 

--- a/src/core/tui.rs
+++ b/src/core/tui.rs
@@ -65,6 +65,10 @@ impl Tui {
             Command::SetTheme(theme) => self.editor.set_theme(&theme),
             Command::NextBuffer => self.editor.next_buffer(),
             Command::PrevBuffer => self.editor.prev_buffer(),
+            Command::MoveLeft => self.editor.move_left(),
+            Command::MoveRight => self.editor.move_right(),
+            Command::MoveUp => self.editor.move_up(),
+            Command::MoveDown => self.editor.move_down(),
             Command::PageDown => self.editor.page_down(),
             Command::PageUp => self.editor.page_up(),
         }

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -170,6 +170,30 @@ impl Editor {
         }
     }
 
+    pub fn move_left(&mut self) {
+        if let Some(view) = self.views.get_mut(&self.current_view) {
+            view.move_left();
+        }
+    }
+
+    pub fn move_right(&mut self) {
+        if let Some(view) = self.views.get_mut(&self.current_view) {
+            view.move_right();
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        if let Some(view) = self.views.get_mut(&self.current_view) {
+            view.move_up();
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if let Some(view) = self.views.get_mut(&self.current_view) {
+            view.move_down();
+        }
+    }
+
     pub fn page_down(&mut self) {
         if let Some(view) = self.views.get_mut(&self.current_view) {
             view.page_down();

--- a/src/widgets/view/view.rs
+++ b/src/widgets/view/view.rs
@@ -106,6 +106,22 @@ impl View {
         self.client.page_up()
     }
 
+    pub fn move_left(&mut self) {
+        self.client.left()
+    }
+
+    pub fn move_right(&mut self) {
+        self.client.right()
+    }
+
+    pub fn move_up(&mut self) {
+        self.client.up()
+    }
+
+    pub fn move_down(&mut self) {
+        self.client.down()
+    }
+
     fn update_window(&mut self) {
         if self.cursor.line < self.cache.before() {
             error!(


### PR DESCRIPTION
This implements the move_left/right/up/down commands.
The mappings are as suggested in issue #70:
  - `ml` / `move-left`
  - `mr` / `move-right`
  - `mu` / `move-up`
  - `md` / `move-down`