### PR TITLE
[WIP] fix(main): don't require file argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn run() -> Result<(), Error> {
         (about: "The Xi Editor")
         (@arg core: -c --core +takes_value "Specify binary to use for the backend")
         (@arg logfile: -l --logfile +takes_value "Log file location")
-        (@arg file: +required "File to edit"));
+        (@arg file: "File to edit"));
 
     let matches = xi.get_matches();
     if let Some(logfile) = matches.value_of("logfile") {


### PR DESCRIPTION
It's entirely reasonable to want to open an empty view, e.g. to create a new document

I guess this also needs a way to specify the filename during save though.