### PR TITLE
Emacs navigation keybindings C-{n, p, f, b}

### DIFF
--- a/src/core/tui.rs
+++ b/src/core/tui.rs
@@ -80,6 +80,10 @@ impl Tui {
         debug!("handling input {:?}", event);
         match event {
             Event::Key(Key::Ctrl('c')) => self.exit = true,
+            Event::Key(Key::Ctrl('n')) => self.editor.move_down(),
+            Event::Key(Key::Ctrl('p')) => self.editor.move_up(),
+            Event::Key(Key::Ctrl('f')) => self.editor.move_right(),
+            Event::Key(Key::Ctrl('b')) => self.editor.move_left(),
             Event::Key(Key::Alt('x')) => {
                 if let Some(ref mut prompt) = self.prompt {
                     match prompt.handle_input(&event) {


### PR DESCRIPTION
Make my life easier, but I'm not sure if we should merge that. Can we
make that keybindings optional or something like that?

That branch exists for a while, but I decided to make a PR.

![image](https://user-images.githubusercontent.com/7642878/98914467-7837e700-24a7-11eb-94a7-578c4397b441.png)


Congrats for all the development!